### PR TITLE
Correction needed in the implementation of Conversion of Infix op

### DIFF
--- a/Infix2Prefix.cpp
+++ b/Infix2Prefix.cpp
@@ -51,7 +51,8 @@ string InfixToPrefix(string s) {
             operatorStack.pop();
         }
         else {
-            while (!operatorStack.empty() && priority(s[i]) <= priority(operatorStack.top())) {
+            // Modified "<=" to "<"
+            while (!operatorStack.empty() && priority(s[i]) < priority(operatorStack.top())) {
                 ans += operatorStack.top();
                 operatorStack.pop();
             }


### PR DESCRIPTION
This change ensures that when an operator with the same precedence as the current one is at the top of the stack, it does not get popped immediately, preserving the left-to-right associativity of operators with the same precedence.